### PR TITLE
Add contributor behavior analysis resources

### DIFF
--- a/outputs/contributor_profile_template.md
+++ b/outputs/contributor_profile_template.md
@@ -1,0 +1,47 @@
+# Contributor Profile: {{ name }}
+
+## \U1F4C6 Activity Overview
+- Commits: {{ total_commits }}
+- Lines Added/Deleted: {{ lines_added }} / {{ lines_deleted }}
+- Active From: {{ first_commit_date }} to {{ last_commit_date }}
+- Primary Languages: {{ languages }}
+
+## \U1F4C1 Domain Ownership
+- Main Areas of Focus:
+  - {{ domain_1 }}
+  - {{ domain_2 }}
+  - {{ domain_3 }}
+
+## \U1F9E0 Design & Coding Philosophy
+- Type safety: {{ type_safety_notes }}
+- Error handling: {{ error_handling_notes }}
+- Config management: {{ config_pattern }}
+- Naming/style: {{ naming_notes }}
+- Testing: {{ testing_notes }}
+
+## \U1F9EA Testing & Quality Strategy
+- Test types: {{ test_types }}
+- Coverage: {{ coverage_notes }}
+- Tools: {{ tools_used }}
+- Quality gates: {{ linting_types }}
+
+## \U1F527 Workflow & Commits
+- Commit style: {{ commit_style }}
+- Branching habits: {{ branching }}
+- Pull request behavior: {{ pr_notes }}
+
+## \U1F6A0 How to Contribute Like {{ name }}
+- \u2705 DO:
+  - Follow {{ pattern_1 }}
+  - Adopt {{ habit_2 }}
+- \u274C DON'T:
+  - Avoid {{ anti_pattern_1 }}
+  - Skip {{ habit_3 }}
+
+## \U1F9EC Code Evolution Patterns
+- Abandoned patterns:
+  - {{ legacy_1 }}
+- Migration leadership:
+  - {{ migration_project }}
+
+---

--- a/prompts/contributor_context_prompt.md
+++ b/prompts/contributor_context_prompt.md
@@ -1,0 +1,113 @@
+## \U1F9E0 Codex Prompt: Contributor Behavior Context Generator
+
+````
+You are a context engineering assistant for software repositories.
+
+Your task is to generate a complete contributor analysis context package from Git metadata and coding patterns, modeled after the analysis of Harshal Sheth in the DataHub repo.
+
+## Input:
+The user will provide:
+- Git commit metadata (e.g., author, commit counts, diffs, files touched)
+- Coding samples from the contributor (optional)
+- Directory structure or file heatmaps (optional)
+
+## You must produce three structured outputs:
+
+---
+
+### 1. \U1F539 Prompt: `prompts/contributor_context_prompt.md`
+
+A reusable prompt designed for Claude or GPT-4 that takes as input:
+- The commit history and modified file paths for a single contributor
+- Sample diffs or full source files (optional)
+
+And returns:
+- Contributor profile
+- Domain ownership map
+- Coding patterns and philosophies
+- Testing and quality mindset
+- Style and commit practices
+- Organizational principles
+- “How to contribute like them” guide
+
+---
+
+### 2. \U1F538 Spec (YAML): `specs/contributor_analysis.yaml`
+
+```yaml
+name: Contributor Behavior Context Spec
+description: Extract contributor patterns, habits, and areas of ownership from Git metadata and sample code.
+inputs:
+  - git_log: Raw log filtered by author (e.g., `git log --author="Harshal Sheth"`)
+  - file_diff_summaries: Optional diffs from their most active files
+  - file_heatmap: Optional frequency counts of files modified
+  - code_samples: Optional function/class samples they've written
+outputs:
+  - top_contributor_profile
+  - domain_ownership_summary
+  - coding_philosophy_and_patterns
+  - testing_and_quality_mindset
+  - developer_workflow
+  - onboarding_alignment_guide
+requirements:
+  - Identify language(s) used
+  - Include sample commit messages
+  - Infer test style and design principles
+  - Infer architecture patterns (if possible)
+  - Detect code evolution themes
+  - Support summarization across multiple repos
+````
+
+---
+
+### 3. \U1F4C4 Markdown Template: `outputs/contributor_profile_template.md`
+
+```markdown
+# Contributor Profile: {{ name }}
+
+## \U1F4C6 Activity Overview
+- Commits: {{ total_commits }}
+- Lines Added/Deleted: {{ lines_added }} / {{ lines_deleted }}
+- Active From: {{ first_commit_date }} to {{ last_commit_date }}
+- Primary Languages: {{ languages }}
+
+## \U1F4C1 Domain Ownership
+- Main Areas of Focus:
+  - {{ domain_1 }}
+  - {{ domain_2 }}
+  - {{ domain_3 }}
+
+## \U1F9E0 Design & Coding Philosophy
+- Type safety: {{ type_safety_notes }}
+- Error handling: {{ error_handling_notes }}
+- Config management: {{ config_pattern }}
+- Naming/style: {{ naming_notes }}
+- Testing: {{ testing_notes }}
+
+## \U1F9EA Testing & Quality Strategy
+- Test types: {{ test_types }}
+- Coverage: {{ coverage_notes }}
+- Tools: {{ tools_used }}
+- Quality gates: {{ linting_types }}
+
+## \U1F527 Workflow & Commits
+- Commit style: {{ commit_style }}
+- Branching habits: {{ branching }}
+- Pull request behavior: {{ pr_notes }}
+
+## \U1F6A0 How to Contribute Like {{ name }}
+- \u2705 DO:
+  - Follow {{ pattern_1 }}
+  - Adopt {{ habit_2 }}
+- \u274C DON'T:
+  - Avoid {{ anti_pattern_1 }}
+  - Skip {{ habit_3 }}
+
+## \U1F9EC Code Evolution Patterns
+- Abandoned patterns:
+  - {{ legacy_1 }}
+- Migration leadership:
+  - {{ migration_project }}
+
+---
+```

--- a/specs/contributor_analysis.yaml
+++ b/specs/contributor_analysis.yaml
@@ -1,0 +1,21 @@
+name: Contributor Behavior Context Spec
+description: Extract contributor patterns, habits, and areas of ownership from Git metadata and sample code.
+inputs:
+  - git_log: Raw log filtered by author (e.g., `git log --author="Harshal Sheth"`)
+  - file_diff_summaries: Optional diffs from their most active files
+  - file_heatmap: Optional frequency counts of files modified
+  - code_samples: Optional function/class samples they've written
+outputs:
+  - top_contributor_profile
+  - domain_ownership_summary
+  - coding_philosophy_and_patterns
+  - testing_and_quality_mindset
+  - developer_workflow
+  - onboarding_alignment_guide
+requirements:
+  - Identify language(s) used
+  - Include sample commit messages
+  - Infer test style and design principles
+  - Infer architecture patterns (if possible)
+  - Detect code evolution themes
+  - Support summarization across multiple repos


### PR DESCRIPTION
## Summary
- add new prompt for analyzing Git contributor behavior
- add spec for contributor behavior context
- add markdown template for contributor profile output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687db534e9e4832daf4ad5e526b9d606